### PR TITLE
Disable all penumbre api for nanos

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -7,7 +7,6 @@ on:
       - main
       - develop
       - master # for safety reasons
-      - dev  # for safety reasons
 
 jobs:
   configure:

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -7,6 +7,7 @@ on:
       - main
       - develop
       - master # for safety reasons
+      - dev # for safety reasons
 
 jobs:
   configure:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
       - main
       - develop
       - master # for safety reasons
-      - dev  # for safety reasons
+      - dev # for safety reasons
 
 jobs:
   analyse:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,61 +58,6 @@ jobs:
           cd ./app/rust
           cargo clippy --all-targets --features "clippy"
 
-  build_ledger:
-    needs: configure
-    runs-on: ubuntu-latest
-    container:
-      image: zondax/ledger-app-builder:latest
-      options: --user ${{ needs.configure.outputs.uid_gid }}
-      env:
-        BOLOS_SDK: /opt/nanos-secure-sdk
-    outputs:
-      size: ${{steps.build.outputs.size}}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Build Standard app
-        id: build
-        shell: bash -l {0}
-        run: |
-          make PRODUCTION_BUILD=0
-          echo "size=$(python3 deps/ledger-zxlib/scripts/getSize.py s)" >> $GITHUB_OUTPUT
-
-  build_ledger_production:
-    needs: configure
-    runs-on: ubuntu-latest
-    container:
-      image: zondax/ledger-app-builder:latest
-      options: --user ${{ needs.configure.outputs.uid_gid }}
-      env:
-        BOLOS_SDK: /opt/nanos-secure-sdk
-    outputs:
-      size: ${{steps.build.outputs.size}}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Build Production app
-        id: build
-        shell: bash -l {0}
-        run: |
-          make PRODUCTION_BUILD=1
-          echo "size=$(python3 deps/ledger-zxlib/scripts/getSize.py s)" >> $GITHUB_OUTPUT
-
-  size_nano_s:
-    needs: build_ledger
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    env:
-      NANOS_LIMIT_SIZE: 136
-    steps:
-      - run: |
-          echo "LNS app size: ${{needs.build_ledger.outputs.size}} KiB"
-          [ ${{needs.build_ledger.outputs.size}} -le $NANOS_LIMIT_SIZE ]
-
   test_zemu:
     runs-on: ${{ github.repository_owner == 'zondax' && 'zondax-runners' || 'ubuntu-latest' }}
     steps:
@@ -157,41 +102,24 @@ jobs:
           name: snapshots-tmp
           path: tests_zemu/snapshots-tmp/
 
-  build_package_nanos:
-    needs: [configure, build_ledger, test_zemu, rust_tests]
-    if: ${{ github.ref == 'refs/heads/master' }}
+  build_ledger:
+    needs: configure
     runs-on: ubuntu-latest
     container:
       image: zondax/ledger-app-builder:latest
       options: --user ${{ needs.configure.outputs.uid_gid }}
       env:
-        BOLOS_SDK: /opt/nanos-secure-sdk
+        BOLOS_SDK: /opt/nanosplus-secure-sdk
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: true
-      - name: Install deps
-        run: pip install ledgerblue
-
-      - name: Build NanoS
+          submodules: recursive
+      - name: Build Standard app
+        id: build
         shell: bash -l {0}
         run: |
-          PRODUCTION_BUILD=0 make
-          mv ./app/pkg/installer_s.sh ./app/pkg/installer_nanos.sh
-      - name: Set tag
-        id: nanos
-        run: echo "tag_name=$(./app/pkg/installer_nanos.sh version)" >> $GITHUB_OUTPUT
-      - name: Create or Update Release (1)
-        id: create_release_0
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          files: ./app/pkg/installer_nanos.sh
-          tag_name: ${{ steps.nanos.outputs.tag_name }}
-          draft: false
-          prerelease: false
+          make PRODUCTION_BUILD=0
 
   build_package_nanosp:
     needs: [configure, build_ledger, test_zemu, rust_tests]

--- a/app/src/apdu_handler.c
+++ b/app/src/apdu_handler.c
@@ -298,22 +298,18 @@ void handleApdu(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) {
             if (rx < APDU_MIN_LENGTH) {
                 THROW(APDU_CODE_WRONG_LENGTH);
             }
-
-            switch (G_io_apdu_buffer[OFFSET_INS]) {
-                case INS_GET_VERSION: {
-                    handle_getversion(flags, tx);
-                    break;
-                }
+            if (G_io_apdu_buffer[OFFSET_INS] == INS_GET_VERSION) {
+                handle_getversion(flags, tx);
+            }
 #if defined(APP_TESTING)
-                case INS_TEST: {
-                    handleTest(flags, tx, rx);
-                    THROW(APDU_CODE_OK);
-                    break;
-                }
+            else if (G_io_apdu_buffer[OFFSET_INS] == INS_TEST) {
+                handleTest(flags, tx, rx);
+                THROW(APDU_CODE_OK);
+            }
 #endif
-                default:
-                    zemu_log("ins_not_supported**\n");
-                    THROW(APDU_CODE_INS_NOT_SUPPORTED);
+            else {
+                zemu_log("ins_not_supported**\n");
+                THROW(APDU_CODE_INS_NOT_SUPPORTED);
             }
         }
         CATCH(EXCEPTION_IO_RESET) { THROW(EXCEPTION_IO_RESET); }

--- a/app/src/apdu_handler.c
+++ b/app/src/apdu_handler.c
@@ -212,6 +212,7 @@ __Z_INLINE void handle_getversion(__Z_UNUSED volatile uint32_t *flags, volatile 
 void handleTest(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) { THROW(APDU_CODE_OK); }
 #endif
 
+#if defined(TARGET_NANOX) || defined(TARGET_NANOS2) || defined(TARGET_STAX) || defined(TARGET_FLEX)
 void handleApdu(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) {
     zemu_log("handleApdu\n");
     volatile uint16_t sw = 0;
@@ -282,3 +283,56 @@ void handleApdu(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) {
     }
     END_TRY;
 }
+#elif defined(TARGET_NANOS)
+void handleApdu(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) {
+    zemu_log("handleApdu\n");
+    volatile uint16_t sw = 0;
+
+    BEGIN_TRY {
+        TRY {
+            if (G_io_apdu_buffer[OFFSET_CLA] != CLA) {
+                zemu_log("CLA not supported\n");
+                THROW(APDU_CODE_CLA_NOT_SUPPORTED);
+            }
+
+            if (rx < APDU_MIN_LENGTH) {
+                THROW(APDU_CODE_WRONG_LENGTH);
+            }
+
+            switch (G_io_apdu_buffer[OFFSET_INS]) {
+                case INS_GET_VERSION: {
+                    handle_getversion(flags, tx);
+                    break;
+                }
+#if defined(APP_TESTING)
+                case INS_TEST: {
+                    handleTest(flags, tx, rx);
+                    THROW(APDU_CODE_OK);
+                    break;
+                }
+#endif
+                default:
+                    zemu_log("ins_not_supported**\n");
+                    THROW(APDU_CODE_INS_NOT_SUPPORTED);
+            }
+        }
+        CATCH(EXCEPTION_IO_RESET) { THROW(EXCEPTION_IO_RESET); }
+        CATCH_OTHER(e) {
+            switch (e & 0xF000) {
+                case 0x6000:
+                case APDU_CODE_OK:
+                    sw = e;
+                    break;
+                default:
+                    sw = 0x6800 | (e & 0x7FF);
+                    break;
+            }
+            G_io_apdu_buffer[*tx] = sw >> 8;
+            G_io_apdu_buffer[*tx + 1] = sw & 0xFF;
+            *tx += 2;
+        }
+        FINALLY {}
+    }
+    END_TRY;
+}
+#endif


### PR DESCRIPTION
- fix nanos compilation issue by removing all penumbra functionality which causes large binary sizes not compatible for that target