### PR TITLE
Feat/spend from

### DIFF
--- a/app/src/apdu_handler.c
+++ b/app/src/apdu_handler.c
@@ -190,7 +190,15 @@ __Z_INLINE void handleSign(volatile uint32_t *flags, volatile uint32_t *tx, uint
         THROW(APDU_CODE_OK);
     }
 
+    // go to the account + randomizer data
+    address_index_t address_index = {0};
+    extractAddressIndex(rx, OFFSET_DATA + sizeof(uint32_t) * HDPATH_LEN_DEFAULT, &address_index);
+
+    // set address index to be used during review
+    tx_setAddressIndex(&address_index);
+
     __Z_UNUSED const char *error_msg = tx_parse();
+
     CHECK_APP_CANARY()
     if (error_msg != NULL) {
         const int error_msg_length = strnlen(error_msg, sizeof(G_io_apdu_buffer));

--- a/app/src/common/parser.h
+++ b/app/src/common/parser.h
@@ -27,6 +27,7 @@ const char *parser_getMsgPackTypeDescription(uint8_t type);
 
 //// parses a tx buffer
 parser_error_t parser_parse(parser_context_t *ctx, const uint8_t *data, size_t dataLen, parser_tx_t *tx_obj);
+void parser_setAddressIndex(parser_context_t *ctx, address_index_t *addr_idx);
 
 //// verifies tx fields
 parser_error_t parser_validate(parser_context_t *ctx);

--- a/app/src/common/tx.c
+++ b/app/src/common/tx.c
@@ -131,3 +131,10 @@ zxerr_t tx_getItem(int8_t displayIdx, char *outKey, uint16_t outKeyLen, char *ou
 
     return zxerr_ok;
 }
+
+void tx_setAddressIndex(address_index_t *addr_idx) {
+    parser_setAddressIndex(&ctx_parsed_tx, addr_idx);
+}
+address_index_t *tx_addressIndex() {
+    return &ctx_parsed_tx.address_index;
+}

--- a/app/src/common/tx.h
+++ b/app/src/common/tx.h
@@ -18,6 +18,7 @@
 #include "coin.h"
 #include "os.h"
 #include "parser_txdef.h"
+#include "keys_def.h"
 #include "zxerror.h"
 
 void tx_initialize();
@@ -56,6 +57,9 @@ const char *tx_parse_metadata();
 
 /// Return the number of items in the transaction
 zxerr_t tx_getNumItems(uint8_t *num_items);
+
+void tx_setAddressIndex(address_index_t *addr_idx);
+address_index_t *tx_addressIndex();
 
 /// Gets an specific item from the transaction (including paging)
 zxerr_t tx_getItem(int8_t displayIdx, char *outKey, uint16_t outKeyLen, char *outValue, uint16_t outValueLen,

--- a/app/src/crypto_helper.c
+++ b/app/src/crypto_helper.c
@@ -17,7 +17,6 @@
 // #include "keys_personalizations.h"
 #include <string.h>
 
-#include "keys_def.h"
 #include "rslib.h"
 #include "zxformat.h"
 
@@ -29,6 +28,25 @@ zxerr_t compute_address(keys_t *keys, uint32_t account, uint8_t *randomizer) {
     }
 
     return zxerr_ok;
+}
+
+zxerr_t compute_local_address(uint32_t account, uint8_t *randomizer, address_t out) {
+    if (out == NULL || randomizer == NULL) return zxerr_unknown;
+
+    zxerr_t error = zxerr_invalid_crypto_settings;
+    keys_t keys = {0};
+
+    CATCH_ZX_ERROR(compute_keys(&keys));
+    CATCH_ZX_ERROR(compute_address(&keys, account, randomizer));
+
+    error = zxerr_ok;
+
+    // copy
+    MEMCPY(out, keys.address, ADDRESS_LEN_BYTES);
+
+catch_zx_error:
+    MEMZERO(&keys, sizeof(keys));
+    return error;
 }
 
 zxerr_t compute_keys(keys_t *keys) {

--- a/app/src/crypto_helper.h
+++ b/app/src/crypto_helper.h
@@ -46,6 +46,7 @@ extern "C" {
     } while (0)
 
 zxerr_t compute_address(keys_t *keys, uint32_t account, uint8_t *randomizer);
+zxerr_t compute_local_address(uint32_t account, uint8_t *randomizer, address_t out);
 zxerr_t compute_keys(keys_t *keys);
 
 #ifdef __cplusplus

--- a/app/src/parser.c
+++ b/app/src/parser.c
@@ -63,6 +63,14 @@ parser_error_t parser_validate(parser_context_t *ctx) {
     return parser_ok;
 }
 
+
+void parser_setAddressIndex(parser_context_t *ctx, address_index_t *addr_idx) {
+    if (ctx == NULL || addr_idx == NULL) {
+        return;
+    }
+    MEMCPY(&ctx->address_index, addr_idx, sizeof(address_index_t));
+}
+
 parser_error_t parser_getNumItems(const parser_context_t *ctx, uint8_t *num_items) {
     // #{TODO} --> function to retrieve num Items
     // *num_items = _getNumItems();

--- a/app/src/plan/spend_plan.c
+++ b/app/src/plan/spend_plan.c
@@ -23,6 +23,8 @@
 #include "zxformat.h"
 #include "known_assets.h"
 #include "note.h"
+#include "crypto_helper.h"
+#include "ui_utils.h"
 
 parser_error_t decode_spend_plan(const bytes_t *data, spend_plan_t *output) {
     penumbra_core_component_shielded_pool_v1_SpendPlan spend_plan =
@@ -81,19 +83,56 @@ parser_error_t spend_getItem(const parser_context_t *ctx, const spend_plan_t *sp
         return err;
     }
 
+    zxerr_t error = zxerr_invalid_crypto_settings;
+    keys_t keys = {0};
 
     switch ( displayIdx ) {
         case 0:
             snprintf(outKey, outKeyLen, "Spend");
-            return printValue(ctx, &spend->note.value, outVal, outValLen);
-            break;
+            char value[VALUE_DISPLAY_MAX_LEN] = {0};
+            CHECK_ERROR(printValue(ctx, &spend->note.value, value, VALUE_DISPLAY_MAX_LEN));
+
+            pageString(outVal, outValLen, value, pageIdx, pageCount);
+
+            return parser_ok;
         case 1:
             snprintf(outKey, outKeyLen, "From");
-            snprintf(outVal, outValLen, "Main Account");
-            break;
+            // Worse scenario where address is not controlled by the user
+            char addr_ui[ENCODED_ADDR_LEN] = {0};
+            uint8_t randomizer[ADDR_RANDOMIZER_LEN] = {0};
+            if (ctx->address_index.has_randomizer) {
+                MEMCPY(randomizer, ctx->address_index.randomizer, ADDR_RANDOMIZER_LEN);
+            }
+
+            CATCH_ZX_ERROR(compute_keys(&keys));
+            CATCH_ZX_ERROR(compute_address(&keys, ctx->address_index.account, randomizer));
+
+            // compare the addresses
+            if (MEMCMP(keys.address, spend->note.address.inner.ptr, ADDRESS_LEN_BYTES) == 0 ) {
+                if (ctx->address_index.account == 0) {
+                    snprintf(outVal, outValLen, "Main-Account");
+                } else {
+                    // We can use %d, because account is an uint32_t
+                    // otherwise u64_to_str or any other alternative
+                    // must be used
+                    snprintf(addr_ui, ENCODED_ADDR_LEN, "Sub-Account %d", ctx->address_index.account);
+                    pageString(outVal, outValLen, addr_ui, pageIdx, pageCount);
+                }
+            } else {
+                // render encoded address in shorter form
+                if (printShortAddress(&keys.address[0], ADDRESS_LEN_BYTES, addr_ui, ENCODED_ADDR_LEN) != parser_ok) {
+                    MEMZERO(&keys, sizeof(keys));
+                    return parser_no_data;
+                }
+                pageString(outVal, outValLen, addr_ui, pageIdx, pageCount);
+            }
+            return parser_ok;
         default:
             return parser_no_data;
     }
-    return parser_ok;
 
+catch_zx_error:
+    MEMZERO(&keys, sizeof(keys));
+
+    return parser_no_data;
 }

--- a/app/src/plan/spend_plan.c
+++ b/app/src/plan/spend_plan.c
@@ -102,6 +102,12 @@ parser_error_t spend_getItem(const parser_context_t *ctx, const spend_plan_t *sp
             uint8_t randomizer[ADDR_RANDOMIZER_LEN] = {0};
             if (ctx->address_index.has_randomizer) {
                 MEMCPY(randomizer, ctx->address_index.randomizer, ADDR_RANDOMIZER_LEN);
+            } else {
+                // regarless the randomizer was initialized with
+                // zeroes, we add this step to make it clear
+                // that in the absent of randomizer, SDK uses
+                // the default [0u8; 12] value
+                MEMZERO(randomizer, ADDR_RANDOMIZER_LEN);
             }
 
             CATCH_ZX_ERROR(compute_keys(&keys));

--- a/app/src/ui/address_display.c
+++ b/app/src/ui/address_display.c
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *   (c) 2018 - 2023 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include "address_display.h"
+#include "crypto_helper.h"
+#include "constants.h"
+#include "ui_utils.h"
+
+parser_error_t print_addressWithOwnership(const address_index_t* address_index, const uint8_t* address, uint16_t addressLen, char* out, uint16_t outLen) {
+    if (address_index == NULL || outLen != ENCODED_ADDR_LEN || addressLen != ADDRESS_LEN_BYTES) {
+        return parser_no_data;
+    }
+    uint8_t randomizer[ADDR_RANDOMIZER_LEN] = {0};
+    address_t local_addr = {0};
+
+    if (address_index->has_randomizer) {
+        MEMCPY(randomizer, address_index->randomizer, ADDR_RANDOMIZER_LEN);
+    }
+
+    if (compute_local_address(address_index->account, randomizer, local_addr) != zxerr_ok) {
+        return parser_unexpected_error;
+    }
+
+    // compare the addresses
+    if (MEMCMP(local_addr, address, ADDRESS_LEN_BYTES) == 0 ) {
+        if (address_index->account == 0) {
+            snprintf(out, outLen, "Main-Account");
+        } else {
+            // We can use %d, because account is an uint32_t
+            // otherwise u64_to_str or any other alternative
+            // must be used
+            snprintf(out, ENCODED_ADDR_LEN, "Sub-Account %d", address_index->account);
+        }
+    } else {
+        // render encoded address in shorter form
+// printShortAddress(uint8_t *address, uint16_t address_len, char *out, uint16_t out_len);
+        if (printShortAddress(address, ADDRESS_LEN_BYTES, out, ENCODED_ADDR_LEN) != parser_ok) {
+            return parser_no_data;
+        }
+    }
+
+    return parser_ok;
+}

--- a/app/src/ui/address_display.h
+++ b/app/src/ui/address_display.h
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *   (c) 2018 - 2023 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+#include <stdint.h>
+
+#include "parser_common.h"
+#include "parser_txdef.h"
+
+#pragma once
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+parser_error_t print_addressWithOwnership(const address_index_t* address_index, const uint8_t* address, uint16_t addressLen, char* out, uint16_t outLen);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+

--- a/app/src/ui_utils.h
+++ b/app/src/ui_utils.h
@@ -50,7 +50,7 @@ parser_error_t printBech32Encoded(const char *prefix, uint16_t prefix_len, const
  *
  * @return parser_error_t   parser_ok on success, error code otherwise
  */
-parser_error_t printShortAddress(uint8_t *address, uint16_t address_len, char *out, uint16_t out_len);
+parser_error_t printShortAddress(const uint8_t *address, uint16_t address_len, char *out, uint16_t out_len);
 parser_error_t printAddress(const uint8_t *address, uint16_t address_len, char *out, uint16_t out_len);
 parser_error_t printAssetId(const uint8_t *asset, uint16_t asset_len, char *out, uint16_t out_len);
 


### PR DESCRIPTION
Add address filtering for renderization:
- owned address are either printed using Main Account(if account is cero) or Sub-Account #accounte_number
- if not owned, prints the shorter form of the address 